### PR TITLE
Fix ReportGenerator-Path in OneClickBuild.targets

### DIFF
--- a/OneClickBuild/build/OneClickBuild.targets
+++ b/OneClickBuild/build/OneClickBuild.targets
@@ -280,7 +280,7 @@
 
   <Target Name="SelectReportGenerator" Condition="'@(ReportGenerator)'==''">
     <PropertyGroup>
-      <_ReportGeneratorPath>$(SolutionDir)packages\ReportGenerator.*\tools\ReportGenerator.exe</_ReportGeneratorPath>
+      <_ReportGeneratorPath>$(SolutionDir)packages\ReportGenerator.*\tools\net47\ReportGenerator.exe</_ReportGeneratorPath>
     </PropertyGroup>
 
     <!--Ensure installed -->


### PR DESCRIPTION
The path, where the ReportGenerator.exe is, changed in newer versions. It's now under tools/net47 (or necoreapp*)